### PR TITLE
user profile circle doesn't collapse if the user specifies an invalid image

### DIFF
--- a/public/stylesheets/style.css
+++ b/public/stylesheets/style.css
@@ -69,9 +69,11 @@ h1 {
 }
 
 .userCircle {
-  background-color: lightgreen;
+  background-color: lightgrey;
   clip-path: circle(50px);
   align-self: center;
+  width: 100px;
+  height: 100px;
 }
 
 .circleContainer {


### PR DESCRIPTION
There was an issue with the header, where the circle that the user's profile picture goes in wouldn't display if they specified an invalid image. Now it just displays a plain grey circle.